### PR TITLE
Modified code

### DIFF
--- a/2. Classify Manhattan with TensorFlow.ipynb
+++ b/2. Classify Manhattan with TensorFlow.ipynb
@@ -580,12 +580,12 @@
    ],
    "source": [
     "# 8,000 pairs for training\n",
-    "latlng_train = latlng_std[0:7999]\n",
-    "is_mt_train = is_mt[0:7999]\n",
+    "latlng_train = latlng_std[0:8000]\n",
+    "is_mt_train = is_mt[0:8000]\n",
     "\n",
     "# 2,000 pairs for test\n",
-    "latlng_test = latlng_std[8000:9999]\n",
-    "is_mt_test = is_mt[8000:9999]\n",
+    "latlng_test = latlng_std[8000:10000]\n",
+    "is_mt_test = is_mt[8000:10000]\n",
     "\n",
     "print \"Split finished.\""
    ]


### PR DESCRIPTION
In list slicing `arr[start:end]`, the `end` always excluded.