### PR TITLE
Add `as_iterable` option to DNNClassifier.predict

### DIFF
--- a/2. Classify Manhattan with TensorFlow.ipynb
+++ b/2. Classify Manhattan with TensorFlow.ipynb
@@ -728,7 +728,7 @@
    "source": [
     "# plot a predicted map of Manhattan\n",
     "def plot_predicted_map():\n",
-    "  is_mt_pred = dnnc.predict(latlng_std) # an array of prediction results\n",
+    "  is_mt_pred = dnnc.predict(latlng_std, as_iterable=False) # an array of prediction results\n",
     "  plt.scatter(lng[is_mt_pred == 1], lat[is_mt_pred == 1], c='b')\n",
     "  plt.scatter(lng[is_mt_pred == 0], lat[is_mt_pred == 0], c='y')\n",
     "  plt.show()\n",


### PR DESCRIPTION
`DNNClassifier.predict` returns an iterable of predicted classes on default.
https://www.tensorflow.org/api_docs/python/tf/contrib/learn/DNNClassifier#predict