### PR TITLE
Add a detail instructon about download directory

### DIFF
--- a/0. Preparation.ipynb
+++ b/0. Preparation.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "## 1-3. Download the codelab materials\n",
     "\n",
-    "From [TensorFlow-Intro repository on GitHub](https://github.com/kazunori279/TensorFlow-Intro), click the green `Clone or download` button, download a zip file, and extract the zip file. You can move the extracted folder `TensorFlow-Intro-master` to anywhere you like. Then open [the top page of your local Datalab folder](http://localhost:8081/tree), navigate to the `TensorFlow-Intro-master` folder, so you will see the list of the codelab materials.\n",
+    "From [TensorFlow-Intro repository on GitHub](https://github.com/kazunori279/TensorFlow-Intro), click the green `Clone or download` button, download a zip file, and extract the zip file. You can move the extracted folder `TensorFlow-Intro-master` to anywhere you like under `${HOME}`. Then open [the top page of your local Datalab folder](http://localhost:8081/tree), navigate to the `TensorFlow-Intro-master` folder, so you will see the list of the codelab materials.\n",
     "\n",
     "![](images/codelab_materials.png)\n",
     "\n",


### PR DESCRIPTION
Docker is mounting ${HOME} as DataVolume according to [Run Cloud Datalab locally](https://cloud.google.com/datalab/docs/quickstarts/quickstart-local), so a user can't access the material If it doesn't download under ${HOME}.
