### PR TITLE
Updated Datalab quickstart URL

### DIFF
--- a/0. Preparation.ipynb
+++ b/0. Preparation.ipynb
@@ -42,8 +42,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Follow the instruction [Use the Datalab command line tool](https://cloud.google.com/datalab/docs/quickstarts/quickstart-cli). \n",
-    "- **Important Note**: This will create a Google Compute Engine instance running on the cloud until you delete it. Please make sure to **[Delete the Datalab](https://cloud.google.com/datalab/docs/quickstarts/quickstart-cli#clean-up)** after finishing the codelab. If you leave Datalab running on the cloud, it possible **you will get charged** for it."
+    "- Follow the instruction [Use the Datalab command line tool](https://cloud.google.com/datalab/docs/quickstarts). \n",
+    "- **Important Note**: This will create a Google Compute Engine instance running on the cloud until you delete it. Please make sure to **[Delete the Datalab](https://cloud.google.com/datalab/docs/quickstarts#clean-up)** after finishing the codelab. If you leave Datalab running on the cloud, it possible **you will get charged** for it."
    ]
   },
   {


### PR DESCRIPTION
Looks like the docs have moved... might be good to add a note also to use the Mac / Windows / Linux tab in the Quickstart doc, not Cloud Shell, which is the default. Or provide alternate instructions to git clone TensorFlow-Intro in the cloud instance.